### PR TITLE
[Fix] Adventure api error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,12 +32,8 @@
                         <configuration>
                             <relocations>
                                 <relocation>
-                                    <pattern>net.kyori.adventure</pattern>
-                                    <shadedPattern>me.chocolf.moneyfrommobs.libs.net.kyori.adventure</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>net.kyori.examination</pattern>
-                                    <shadedPattern>me.chocolf.moneyfrommobs.libs.net.kyori.examination</shadedPattern>
+                                    <pattern>net.kyori</pattern>
+                                    <shadedPattern>me.chocolf.moneyfrommobs.libs.net.kyori</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.intellij</pattern>
@@ -193,6 +189,11 @@
             <groupId>net.kyori</groupId>
             <artifactId>adventure-platform-bukkit</artifactId>
             <version>4.3.4</version>
+        </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-api</artifactId>
+            <version>4.17.0</version>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>


### PR DESCRIPTION
### Description
This pull request adds missing dependency and fixes error related to `Codec`

### Error
```lua
[Server thread/ERROR]: Error occurred while enabling MoneyFromMobs v4.9 (Is it up to date?)
java.lang.NoSuchMethodError: 'me.chocolf.moneyfrommobs.libs.net.kyori.adventure.util.Codec me.chocolf.moneyfrommobs.libs.net.kyori.adventure.util.Codec.codec(me.chocolf.moneyfrommobs.libs.net.kyori.adventure.util.Codec$Decoder, me.chocolf.moneyfrommobs.libs.net.kyori.adventure.util.Codec$Encoder)'
	at me.chocolf.moneyfrommobs.libs.net.kyori.adventure.text.serializer.gson.legacyimpl.NBTLegacyHoverEventSerializerImpl.<clinit>(NBTLegacyHoverEventSerializerImpl.java:43) ~[MoneyFromMobs-4.8.1.jar:?]
	at me.chocolf.moneyfrommobs.libs.net.kyori.adventure.text.serializer.gson.legacyimpl.NBTLegacyHoverEventSerializer.get(NBTLegacyHoverEventSerializer.java:43) ~[MoneyFromMobs-4.8.1.jar:?]
	at me.chocolf.moneyfrommobs.libs.net.kyori.adventure.platform.bukkit.BukkitComponentSerializer.<clinit>(BukkitComponentSerializer.java:68) ~[MoneyFromMobs-4.8.1.jar:?]
	at me.chocolf.moneyfrommobs.managers.MessageManager.applyColour(MessageManager.java:126) ~[MoneyFromMobs-4.8.1.jar:?]
	at me.chocolf.moneyfrommobs.MoneyFromMobs.onEnable(MoneyFromMobs.java:53) ~[MoneyFromMobs-4.8.1.jar:?]
	at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:281) ~[purpur-api-1.20.2-R0.1-SNAPSHOT.jar:?]
```